### PR TITLE
Updated macOS build to 10.15 (Catalina)

### DIFF
--- a/azure-tidyverse.yml
+++ b/azure-tidyverse.yml
@@ -41,7 +41,7 @@ jobs:
       CI: true
       ${{ insert }}: ${{ parameters.env }}
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.15'
     steps:
       - template: templates/r-setup-macOS.yml
       - template: templates/pkg-workflow.yml


### PR DESCRIPTION
Microsoft has announced [they're deprecating macOS `10.13`](https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/) by March 20th, 2020. They are now supporting `10.14` and `10.15`. This bumps the macOS version from `10.13` to `10.15` to reflect the latest available operating system.

Successfully tested this on a private Azure Pipelines instance.